### PR TITLE
Find Available PDF shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+* In version 3.8.0:
+
+    + Add find available PDFs shortcut
+
+* In version 3.7.0:
+
+    + Add ZotFile Quick Extract shortcut
+
 * In version 3.6.1:
 
     + Update French locale

--- a/addon/chrome/content/zutilo/keys.js
+++ b/addon/chrome/content/zutilo/keys.js
@@ -265,6 +265,15 @@ keys.shortcuts.renameSelectedAttachmentsFromParents = function(win) {
     // jscs: enable requireCamelCaseOrUpperCaseIdentifiers
 };
 
+keys.categories.findPDF = 'attachments'
+keys.shortcuts.findPDF = function(win)
+{
+    // jscs: disable requireCamelCaseOrUpperCaseIdentifiers
+    let items = win.ZoteroPane_Local.getSelectedItems();
+    win.Zotero.Attachments.addAvailablePDFs(items);
+    // jscs: enable requireCamelCaseOrUpperCaseIdentifiers
+};
+
 keys.categories.attachURI = 'attachments'
 keys.shortcuts.attachURI = function(win) {
     // jscs: disable requireCamelCaseOrUpperCaseIdentifiers
@@ -493,7 +502,7 @@ AddonManager.getAddonByID('zotfile@columbia.edu', function(aAddon) {
     keys.shortcuts.ZotFileRename = function(win) {
         win.Zotero.ZotFile.renameSelectedAttachments()
     }
-    
+
     keys.categories.ZotFileExtractAnnotations = 'ZotFile'
     keys.shortcuts.ZotFileExtractAnnotations = function(win) {
         win.Zotero.Zotfile.pdfAnnotations.getAnnotations()

--- a/addon/chrome/locale/de/zutilo/zutilo.properties
+++ b/addon/chrome/locale/de/zutilo/zutilo.properties
@@ -145,6 +145,7 @@ zutilo.shortcuts.name.recognizeSelected        = Rufe Metadaten für PDF-Datei a
 zutilo.shortcuts.name.createParentItemsFromSelected = Erstelle übergeordneten Eintrag
 zutilo.shortcuts.name.renameSelectedAttachmentsFromParents = Datei umbenennen
 zutilo.shortcuts.name.attachURI = Attachments: Attach link to URI
+zutilo.shortcuts.name.findPDF = Find Available PDFs
 zutilo.shortcuts.name.attachStoredFile = Attachments: Attach stored copy of file
 zutilo.shortcuts.name.showFile              = Show attached file
 zutilo.shortcuts.name.copyJSON              = Copy item fields

--- a/addon/chrome/locale/en-US/zutilo/zutilo.properties
+++ b/addon/chrome/locale/en-US/zutilo/zutilo.properties
@@ -145,6 +145,7 @@ zutilo.shortcuts.name.recognizeSelected        = Retrieve metadata for PDF
 zutilo.shortcuts.name.createParentItemsFromSelected = Create parent item
 zutilo.shortcuts.name.renameSelectedAttachmentsFromParents = Rename attachments
 zutilo.shortcuts.name.attachURI = Attachments: Attach link to URI
+zutilo.shortcuts.name.findPDF = Find Available PDFs
 zutilo.shortcuts.name.attachStoredFile = Attachments: Attach stored copy of file
 zutilo.shortcuts.name.showFile              = Show attached file
 zutilo.shortcuts.name.copyJSON              = Copy item fields

--- a/addon/chrome/locale/es/zutilo/zutilo.properties
+++ b/addon/chrome/locale/es/zutilo/zutilo.properties
@@ -145,6 +145,7 @@ zutilo.shortcuts.name.recognizeSelected        = Extraer los metadatos para el P
 zutilo.shortcuts.name.createParentItemsFromSelected = Crear ítem contenedor
 zutilo.shortcuts.name.renameSelectedAttachmentsFromParents = Poner nombre a los ficheros
 zutilo.shortcuts.name.attachURI = Attachments: Attach link to URI
+zutilo.shortcuts.name.findPDF = Find Available PDFs
 zutilo.shortcuts.name.attachStoredFile = Attachments: Attach stored copy of file
 zutilo.shortcuts.name.showFile              = Show attached file
 zutilo.shortcuts.name.copyJSON              = Copy item fields

--- a/addon/chrome/locale/fr/zutilo/zutilo.properties
+++ b/addon/chrome/locale/fr/zutilo/zutilo.properties
@@ -145,6 +145,7 @@ zutilo.shortcuts.name.recognizeSelected        = Récupérer les métadonnées d
 zutilo.shortcuts.name.createParentItemsFromSelected = Créer un document parent
 zutilo.shortcuts.name.renameSelectedAttachmentsFromParents = Renommer les fichiers à partir des métadonnées du parent
 zutilo.shortcuts.name.attachURI = Pièces jointes : joindre un lien vers un URI
+zutilo.shortcuts.name.findPDF = Find Available PDFs
 zutilo.shortcuts.name.attachStoredFile = Pièces jointes : joindre une copie enregistrée d'un fichier
 zutilo.shortcuts.name.showFile              = Afficher le fichier joint
 zutilo.shortcuts.name.copyJSON              = Copier les champs de la notice

--- a/addon/chrome/locale/zh-CN/zutilo/zutilo.properties
+++ b/addon/chrome/locale/zh-CN/zutilo/zutilo.properties
@@ -145,6 +145,7 @@ zutilo.shortcuts.name.recognizeSelected        = 从PDF读取源数据
 zutilo.shortcuts.name.createParentItemsFromSelected = 创建父条目
 zutilo.shortcuts.name.renameSelectedAttachmentsFromParents = 重命名附件
 zutilo.shortcuts.name.attachURI = 附件: 添加到 URI 的链接
+zutilo.shortcuts.name.findPDF = Find Available PDFs
 zutilo.shortcuts.name.attachStoredFile = 附件: 添加已存文件副本
 zutilo.shortcuts.name.showFile              = Show attached file
 zutilo.shortcuts.name.copyJSON              = Copy item fields

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -219,6 +219,9 @@ However, when the pane is shown, the thicker vertical divider ("splitter", "grip
 * __Create parent item:__
     Create a parent item for the currently selected attachment item that does not have a parent.
 
+* __Find available PDFs:__
+    Find available PDFs for selected items.
+
 * __Rename attachments:__
     Use the parent item's metadata to rename its attachments.
 

--- a/i18n/de/readme/CHANGELOG.md
+++ b/i18n/de/readme/CHANGELOG.md
@@ -1,3 +1,11 @@
+* In version 3.8.0:
+
+    + Add find available PDFs shortcut
+
+* In version 3.7.0:
+
+    + Add ZotFile Quick Extract shortcut
+
 * In version 3.6.1:
 
     + Update French locale

--- a/i18n/de/readme/docs/COMMANDS.md
+++ b/i18n/de/readme/docs/COMMANDS.md
@@ -219,6 +219,9 @@ However, when the pane is shown, the thicker vertical divider ("splitter", "grip
 * __Create parent item:__
     Create a parent item for the currently selected attachment item that does not have a parent.
 
+* __Find available PDFs:__
+    Find available PDFs for selected items.
+
 * __Rename attachments:__
     Use the parent item's metadata to rename its attachments.
 

--- a/i18n/en-US/readme/CHANGELOG.md
+++ b/i18n/en-US/readme/CHANGELOG.md
@@ -1,3 +1,11 @@
+* In version 3.8.0:
+
+    + Add find available PDFs shortcut
+
+* In version 3.7.0:
+
+    + Add ZotFile Quick Extract shortcut
+
 * In version 3.6.1:
 
     + Update French locale

--- a/i18n/en-US/readme/docs/COMMANDS.md
+++ b/i18n/en-US/readme/docs/COMMANDS.md
@@ -219,6 +219,9 @@ However, when the pane is shown, the thicker vertical divider ("splitter", "grip
 * __Create parent item:__
     Create a parent item for the currently selected attachment item that does not have a parent.
 
+* __Find available PDFs:__
+    Find available PDFs for selected items.
+
 * __Rename attachments:__
     Use the parent item's metadata to rename its attachments.
 

--- a/i18n/es/readme/CHANGELOG.md
+++ b/i18n/es/readme/CHANGELOG.md
@@ -1,3 +1,11 @@
+* In version 3.8.0:
+
+    + Add find available PDFs shortcut
+
+* In version 3.7.0:
+
+    + Add ZotFile Quick Extract shortcut
+
 * In version 3.6.1:
 
     + Update French locale

--- a/i18n/es/readme/docs/COMMANDS.md
+++ b/i18n/es/readme/docs/COMMANDS.md
@@ -219,6 +219,9 @@ However, when the pane is shown, the thicker vertical divider ("splitter", "grip
 * __Create parent item:__
     Create a parent item for the currently selected attachment item that does not have a parent.
 
+* __Find available PDFs:__
+    Find available PDFs for selected items.
+
 * __Rename attachments:__
     Use the parent item's metadata to rename its attachments.
 

--- a/i18n/fr/readme/CHANGELOG.md
+++ b/i18n/fr/readme/CHANGELOG.md
@@ -1,3 +1,11 @@
+* In version 3.8.0:
+
+    + Add find available PDFs shortcut
+
+* In version 3.7.0:
+
+    + Add ZotFile Quick Extract shortcut
+
 * In version 3.6.1:
 
     + Update French locale

--- a/i18n/fr/readme/docs/COMMANDS.md
+++ b/i18n/fr/readme/docs/COMMANDS.md
@@ -219,6 +219,9 @@ Toutefois, lorsque le volet est affiché, le séparateur vertical plus épais (o
 * __Créer un document parent :__ 
   Crée un document parent pour le document de type pièce jointe sélectionné qui n'a pas de parent.
 
+* __Find available PDFs:__
+    Find available PDFs for selected items.
+
 * __Renommer les fichiers à partir des métadonnées du parent :__ 
   Utilise les métadonnées du document parent pour renommer ses pièces jointes.
 

--- a/i18n/zh-CN/readme/CHANGELOG.md
+++ b/i18n/zh-CN/readme/CHANGELOG.md
@@ -1,3 +1,11 @@
+* In version 3.8.0:
+
+    + Add find available PDFs shortcut
+
+* In version 3.7.0:
+
+    + Add ZotFile Quick Extract shortcut
+
 * In version 3.6.1:
 
     + Update French locale

--- a/i18n/zh-CN/readme/docs/COMMANDS.md
+++ b/i18n/zh-CN/readme/docs/COMMANDS.md
@@ -219,6 +219,9 @@ However, when the pane is shown, the thicker vertical divider ("splitter", "grip
 * __Create parent item:__
     Create a parent item for the currently selected attachment item that does not have a parent.
 
+* __Find available PDFs:__
+    Find available PDFs for selected items.
+
 * __Rename attachments:__
     Use the parent item's metadata to rename its attachments.
 


### PR DESCRIPTION
Hi @wshanks !
I've began working on my own fork thinking this repo was dead :)

Anyway, if you like you can include this functionality to keys.js:

`
keys.categories.findPDF = 'attachments'
keys.shortcuts.findPDF = function(win)
{
    var items = win.ZoteroPane_Local.getSelectedItems();
    win.Zotero.Attachments.addAvailablePDFs(items);
};`

(and also stub or better localizations) 

I'm pasting the code here because my js formatter mangled the original file and the addition is small.