### PR TITLE
Fix show file shortcut when attachments selected

### DIFF
--- a/addon/chrome/content/zutilo/keys.js
+++ b/addon/chrome/content/zutilo/keys.js
@@ -296,7 +296,7 @@ keys.shortcuts.showFile = function(win) {
 
     var _getBestFile = win.Zotero.Promise.coroutine(function* (item) {
         if(item.isAttachment()) {
-            if(item.attachmentLinkMode === Zotero.Attachments.LINK_MODE_LINKED_URL) return false;
+            if(item.attachmentLinkMode === win.Zotero.Attachments.LINK_MODE_LINKED_URL) return false;
             return item;
         } else {
             return yield item.getBestAttachment();


### PR DESCRIPTION
While working on #184, I noticed that there was a small bug in the show file shortcut. It only worked for Zotero main items, not for attachments.