### PR TITLE
Zotero 5.0.97-beta.39+ compatibility fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* In version 3.10.0:
+
+    + Fixes for Zotero 5.0.97-beta and upcoming Zotero 6
+
 * In version 3.9.0:
 
     + Fix Open Style Editor shortcut

--- a/addon/chrome/content/zutilo/keys.js
+++ b/addon/chrome/content/zutilo/keys.js
@@ -340,8 +340,11 @@ keys.shortcuts.openStyleEditor = function(win) {
 keys.categories.generateReport = 'other'
 keys.shortcuts.generateReport = function(win) {
     let context = win.ZoteroPane.document.defaultView
-    if (context.document.activeElement.id == "zotero-collections-tree") {
-            context.Zotero_Report_Interface.loadCollectionReport()
+    // Zotero >=6
+    if (context.document.activeElement.id == win.ZoteroPane.collectionsView.id
+            // Zotero <=5
+            || context.document.activeElement.id == "zotero-collections-tree") {
+        context.Zotero_Report_Interface.loadCollectionReport()
     } else {
         // "zotero-items-tree" whether it is the active element or not
         let zitems = win.ZoteroPane.getSelectedItems()
@@ -355,11 +358,33 @@ keys.categories.focusZoteroCollectionsTree = 'uinavigation'
 keys.shortcuts.focusZoteroCollectionsTree = function(win) {
     win.ZutiloChrome.zoteroOverlay.
         updatePaneVisibility('zotero-collections', 'show');
-    win.document.getElementById('zotero-collections-tree').focus();
+    // Zotero >=6
+    if (win.ZoteroPane.collectionsView.focus) {
+        win.ZoteroPane.collectionsView.focus();
+    }
+    // Zotero 5.0.97-beta.39
+    else if (win.document.getElementById('collection-tree')) {
+        win.document.getElementById('collection-tree').focus();
+    }
+    // Zotero <=5
+    else {
+        win.document.getElementById('zotero-collections-tree').focus();
+    }
 };
 keys.categories.focusZoteroItemsTree = 'uinavigation'
 keys.shortcuts.focusZoteroItemsTree = function(win) {
-    win.document.getElementById('zotero-items-tree').focus();
+    // Zotero >=6
+    if (win.ZoteroPane.itemsView.focus) {
+        win.ZoteroPane.itemsView.focus();
+    }
+    // Zotero 5.0.97-beta.39
+    else if (win.ZoteroPane.itemsView.tree && win.ZoteroPane.itemsView.tree.focus) {
+        win.ZoteroPane.itemsView.tree.focus();
+    }
+    // Zotero <=5
+    else {
+        win.document.getElementById('zotero-items-tree').focus();
+    }
 };
 keys.categories.advanceTabboxTab = 'uinavigation'
 keys.shortcuts.advanceTabboxTab = function(win) {

--- a/addon/chrome/content/zutilo/zoteroOverlay.js
+++ b/addon/chrome/content/zutilo/zoteroOverlay.js
@@ -31,7 +31,8 @@ ZutiloChrome.zoteroOverlay = {
     /******************************************/
     // Window load handling
     /******************************************/
-    init: function() {
+    init: async function() {
+        await Zotero.uiReadyPromise;
         this.fullOverlay();
 
         document.getElementById('zotero-itemmenu').addEventListener('popupshowing', refreshZoteroItemPopup, false)

--- a/i18n/de/readme/CHANGELOG.md
+++ b/i18n/de/readme/CHANGELOG.md
@@ -1,3 +1,7 @@
+* In version 3.10.0:
+
+    + Fixes for Zotero 5.0.97-beta and upcoming Zotero 6
+
 * In version 3.9.0:
 
     + Fix Open Style Editor shortcut

--- a/i18n/en-US/readme/CHANGELOG.md
+++ b/i18n/en-US/readme/CHANGELOG.md
@@ -1,3 +1,7 @@
+* In version 3.10.0:
+
+    + Fixes for Zotero 5.0.97-beta and upcoming Zotero 6
+
 * In version 3.9.0:
 
     + Fix Open Style Editor shortcut

--- a/i18n/es/readme/CHANGELOG.md
+++ b/i18n/es/readme/CHANGELOG.md
@@ -1,3 +1,7 @@
+* In version 3.10.0:
+
+    + Fixes for Zotero 5.0.97-beta and upcoming Zotero 6
+
 * In version 3.9.0:
 
     + Fix Open Style Editor shortcut

--- a/i18n/fr/readme/CHANGELOG.md
+++ b/i18n/fr/readme/CHANGELOG.md
@@ -1,3 +1,7 @@
+* In version 3.10.0:
+
+    + Fixes for Zotero 5.0.97-beta and upcoming Zotero 6
+
 * In version 3.9.0:
 
     + Fix Open Style Editor shortcut

--- a/i18n/zh-CN/readme/CHANGELOG.md
+++ b/i18n/zh-CN/readme/CHANGELOG.md
@@ -1,3 +1,7 @@
+* In version 3.10.0:
+
+    + Fixes for Zotero 5.0.97-beta and upcoming Zotero 6
+
 * In version 3.9.0:
 
     + Fix Open Style Editor shortcut


### PR DESCRIPTION
I didn't test this extensively, but I suspect this will do the trick. It gets rid of the error in zotero/zotero#2159 and fixes keyboard shortcuts (#203). Anything that touches the UI should wait for `uiReadyPromise`.