### PR TITLE
add new shortcut for adding note from annotations

### DIFF
--- a/addon/chrome/content/zutilo/keys.js
+++ b/addon/chrome/content/zutilo/keys.js
@@ -264,6 +264,10 @@ keys.shortcuts.renameSelectedAttachmentsFromParents = function(win) {
     win.ZoteroPane_Local.renameSelectedAttachmentsFromParents()
     // jscs: enable requireCamelCaseOrUpperCaseIdentifiers
 };
+keys.categories.addNoteFromAnnotationsFromSelected = 'itemcreation'
+keys.shortcuts.addNoteFromAnnotationsFromSelected = function(win) {
+    win.ZoteroPane.addNoteFromAnnotationsFromSelected();
+};
 
 keys.categories.findPDF = 'attachments'
 keys.shortcuts.findPDF = function(win)

--- a/addon/chrome/locale/en-US/zutilo/zutilo.properties
+++ b/addon/chrome/locale/en-US/zutilo/zutilo.properties
@@ -146,6 +146,7 @@ zutilo.shortcuts.name.openStyleEditor        = Open Style Editor
 zutilo.shortcuts.name.recognizeSelected        = Retrieve metadata for PDF
 zutilo.shortcuts.name.createParentItemsFromSelected = Create parent item
 zutilo.shortcuts.name.renameSelectedAttachmentsFromParents = Rename attachments
+zutilo.shortcuts.name.addNoteFromAnnotationsFromSelected = Add note from annotations
 zutilo.shortcuts.name.attachURI = Attachments: Attach link to URI
 zutilo.shortcuts.name.findPDF = Find Available PDFs
 zutilo.shortcuts.name.attachStoredFile = Attachments: Attach stored copy of file


### PR DESCRIPTION
See title. This adds a shortcut for the following command:

<img width="449" alt="Screen Shot 2023-03-13 at 3 15 47 AM" src="https://user-images.githubusercontent.com/36142229/224632595-57b7d3bf-42b9-4a5e-b56c-d9c8aaacbb8b.png">

Resolves #228
Resolves #183