### PR TITLE
Updates for Zotero 7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+* In version 4.0.1:
+
+    + Fixes for Zotero 7.1
+
+* In version 4.0.0:
+
+    + Fixes for Zotero 7.0
+    + New copy item IDs function
+
 * In version 3.10.0:
 
     + Fixes for Zotero 5.0.97-beta and upcoming Zotero 6

--- a/addon/chrome/content/zutilo/keyconfig_adapted.js
+++ b/addon/chrome/content/zutilo/keyconfig_adapted.js
@@ -9,7 +9,6 @@
 /* global Zutilo */
 var Cc = Components.classes
 var Ci = Components.interfaces
-Components.utils.import('resource://gre/modules/Services.jsm');
 
 var gPrefService = Components.classes['@mozilla.org/preferences-service;1'].
     getService(Components.interfaces.nsIPrefService).getBranch('');

--- a/addon/chrome/content/zutilo/keys.js
+++ b/addon/chrome/content/zutilo/keys.js
@@ -12,7 +12,6 @@
 // Include core modules and built-in modules
 /********************************************/
 Components.utils.import('resource://gre/modules/AddonManager.jsm');
-Components.utils.import('resource://gre/modules/Services.jsm');
 Components.utils.import('chrome://zutilo/content/zutilo.js');
 
 /********************************************/

--- a/addon/chrome/content/zutilo/zoteroOverlay.js
+++ b/addon/chrome/content/zutilo/zoteroOverlay.js
@@ -7,7 +7,6 @@
 /* global window, document, Components */
 /* global Zotero, ZoteroPane, ZOTERO_CONFIG */
 /* global Zutilo, ZutiloChrome */
-Components.utils.import('resource://gre/modules/Services.jsm');
 Components.utils.import('chrome://zutilo/content/zutilo.js');
 Components.utils.import('resource://zotero/config.js');
 
@@ -178,10 +177,9 @@ ZutiloChrome.zoteroOverlay = {
     /******************************************/
     _copyToClipboard: function(clipboardText) {
         if (clipboardText) {
-            const gClipboardHelper =
-                Components.classes['@mozilla.org/widget/clipboardhelper;1']
-                .getService(Components.interfaces.nsIClipboardHelper);
-            gClipboardHelper.copyString(clipboardText, document);
+            Components.classes['@mozilla.org/widget/clipboardhelper;1']
+                .getService(Components.interfaces.nsIClipboardHelper)
+                .copyString(clipboardText);
         } else {
             var prompts = Services.prompt;
             var title = Zutilo.getString('zutilo.error.copynoitemstitle')

--- a/addon/chrome/content/zutilo/zutilo.js
+++ b/addon/chrome/content/zutilo/zutilo.js
@@ -9,7 +9,6 @@
 var EXPORTED_SYMBOLS = ['Zutilo'];
 
 const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
-Cu.import('resource://gre/modules/Services.jsm');
 var Zotero = null
 
 /**

--- a/addon/chrome/content/zutilo/zutiloChrome.js
+++ b/addon/chrome/content/zutilo/zutiloChrome.js
@@ -12,7 +12,6 @@ var Cc = Components.classes
 var Ci = Components.interfaces
 var Cu = Components.utils
 Cu.import('resource://gre/modules/AddonManager.jsm');
-Cu.import('resource://gre/modules/Services.jsm');
 Cu.import('chrome://zutilo/content/zutilo.js');
 
 /******************************************/

--- a/addon/install.rdf
+++ b/addon/install.rdf
@@ -5,7 +5,7 @@
     <Description about="urn:mozilla:install-manifest">
         <em:id>zutilo@www.wesailatdawn.com</em:id>
         <em:name>Zutilo Utility for Zotero</em:name>
-        <em:version>4.0.0</em:version>
+        <em:version>4.0.1</em:version>
         <em:multiprocessCompatible>true</em:multiprocessCompatible>
         <em:updateURL>https://raw.githubusercontent.com/wshanks/Zutilo/release/deploy/update.rdf</em:updateURL>
 

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Zutilo Utility for Zotero",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A utility adding assorted macros for Zotero",
   "author": "Will Shanks",
   "icons": {

--- a/deploy/updates.json
+++ b/deploy/updates.json
@@ -18,6 +18,16 @@
           "applications": {
             "zotero": {
               "strict_min_version": "7.0.0",
+              "strict_max_version": "7.0.*"
+            }
+          }
+        },
+        {
+          "version": "4.0.1",
+          "update_link": "https://github.com/wshanks/Zutilo/releases/download/v4.0.1/zutilo.xpi",
+          "applications": {
+            "zotero": {
+              "strict_min_version": "7.0.0",
               "strict_max_version": "7.*"
             }
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zutilo",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zutilo",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Zotero plugin providing some additional editing features",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
* Remove references to Services which is now loaded by default
* Adjust the `copyString()` call for copying text to the clipboard
* Update changelog and version for Zutilo 4.0.1